### PR TITLE
Iter64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ BSC_FLAGS = XLEN=$(XLEN) TEST_COUNT=$(TEST_COUNT)
 
 #HW_DBG = on # enables nice debug prints in HW simulation (archive dir only)
 TEST_VERBOSE = on # enables info to come out of tests
-HW_DIAG      = on # enables stat prints, cycle reg in bit manip modules
-TB_HARD_FAIL = on
+#HW_DIAG      = on # enables stat prints, cycle reg in bit manip modules
+#TB_HARD_FAIL = on # when running ModuleTb, $finish(0) is called on first error
 
 ifdef TEST_VERBOSE
 BSC_FLAGS += TEST_VERBOSE=on
@@ -138,11 +138,11 @@ test-all: $(TB_DIR)
 all:
 	make utils
 	make bram
-#	make bram XLEN=64
+	make bram XLEN=64
 	make ModuleTb
 	$(MAKE) -C $(BSV) clean
-#	make ModuleTb XLEN=64
-#	$(MAKE) -C $(BSV) clean
+	make ModuleTb XLEN=64
+	$(MAKE) -C $(BSV) clean
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ BSC_FLAGS = XLEN=$(XLEN) TEST_COUNT=$(TEST_COUNT)
 
 #HW_DBG = on # enables nice debug prints in HW simulation (archive dir only)
 TEST_VERBOSE = on # enables info to come out of tests
-#HW_DIAG      = on # enables stat prints, cycle reg in bit manip modules
+HW_DIAG      = on # enables stat prints, cycle reg in bit manip modules
 TB_HARD_FAIL = on
 
 ifdef TEST_VERBOSE
@@ -137,12 +137,12 @@ test-all: $(TB_DIR)
 .PHONY: all
 all:
 	make utils
-#	make bram
-	make bram XLEN=64
-#	make ModuleTb
+	make bram
+#	make bram XLEN=64
+	make ModuleTb
 	$(MAKE) -C $(BSV) clean
-	make ModuleTb XLEN=64
-	$(MAKE) -C $(BSV) clean
+#	make ModuleTb XLEN=64
+#	$(MAKE) -C $(BSV) clean
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ XLEN ?= 32# set default to 32 or 64 bit
 ##                                             ##
 #################################################
 
-TEST_COUNT ?= 32    # Number of tests to run
+TEST_COUNT ?= 16    # Number of tests to run
 
 TB_DIR  = $(PROJ_HOME)/tb$(XLEN)
 BSC_FLAGS = XLEN=$(XLEN) TEST_COUNT=$(TEST_COUNT)
@@ -23,6 +23,7 @@ BSC_FLAGS = XLEN=$(XLEN) TEST_COUNT=$(TEST_COUNT)
 #HW_DBG = on # enables nice debug prints in HW simulation (archive dir only)
 TEST_VERBOSE = on # enables info to come out of tests
 #HW_DIAG      = on # enables stat prints, cycle reg in bit manip modules
+TB_HARD_FAIL = on
 
 ifdef TEST_VERBOSE
 BSC_FLAGS += TEST_VERBOSE=on
@@ -37,6 +38,9 @@ endif
 BSV = $(PROJ_HOME)/bsv
 ifdef HW_DIAG
 BSC_FLAGS += HW_DIAG=on
+endif
+ifdef TB_HARD_FAIL
+BSC_FLAGS += TB_HARD_FAIL=on
 endif
 
 #################################################
@@ -133,11 +137,12 @@ test-all: $(TB_DIR)
 .PHONY: all
 all:
 	make utils
-	make bram
-#	make bram XLEN=64
-	make ModuleTb
-#	$(MAKE) -C $(BSV) clean
-#	make ModuleTb XLEN=64
+#	make bram
+	make bram XLEN=64
+#	make ModuleTb
+	$(MAKE) -C $(BSV) clean
+	make ModuleTb XLEN=64
+	$(MAKE) -C $(BSV) clean
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -4,18 +4,44 @@ This project is a build up to implement the proposed RISC-V X-BitManip extension
 
 ## Contents
 
-- `archive/` -- Contains Bluespec sources where modules are dedicated in a loosely related operational fashion (bit counts, rotation, etc).  While these will work properly, they will not be used to implement the Bitmanip extension.  The modules may be interesting for verification of other possibly more optimized modules.
-- `bsv/` -- Contains the Bluespec sources for the Bitmanip Modules and Testbenches. Contains a Makefile to build Bluespec to bluesim testbenches (_complete_) and verilog (_coming soon_).  Will contain the RISCV_BBox module (_coming soon_)
-- `util/` -- Contains C source files to create a program to generate hex files for testing brams and simple bitmanip repls for quick gut checks.  Also contains a Makefile to build said programs (_complete_)
-- `LICENSE` -- This repo is licensed under Apache-2.0, mainly to match with Piccolo and Flute
-- `Makefile` -- Makefile to build bitmanip tools.  For options, invoke `make help`
-- `README.md` -- You're reading me
+Below is a listing of the suddirectories and files in this project with descriptions.
+
+### archive
+
+This directory contains standalone bluespec modules to implement the full host of bitmanip extensions in both 32 and 64 bit.  The modules themselves are not too useful for implementing the Bit Manip Extension though they could be used for that.  They should be valuable in a testing framework since they do provide another means of calculating the desired results.  This dir has its own Makefile for building to BlueSim (verilog might be nice to have, but is not a high priority at all), and can be built from the main project Makefile.
+
+### bsv
+
+This directory contains bluespec that can be utilized to implement the RV32 and RV64 Bit Manip extension in a better manner than `archive`.  It has its own makefile that can be directly called, but the main project Makefile is preferable for building the modules here.  Build Targets:
+
+- RV32 Variable Latency BlueSim (**complete**)    Verilog (**coming soon**)
+- RV64 Variable Latency BlueSim (**complete**)    Verilog (**coming soon**)
+- RV32 BBox Wrapper     BlueSim (**coming soon**) Verilog (**coming soon**)
+- RV64 BBox Wrapper     BlueSim (**comint soon**) Verilog (**coming soon**)
+
+### util
+
+Contains C sources for building programs that create hex files to be imported by bluespec as BRAMs for testing purposes.  It also contains sources to make a simple bitmanip repl for on the fly gut checks.  Makefile to compile everything.
+
+### LICENSE
+
+Apache-2.0: chosen to match the BlueSpec Piccolo and Flute
+
+### Makefile
+
+Main Makefile to build various targets in the project.  `make` will build everything in the utils directory, the BitManipIter Module Testbench in bsv, and leave you in a good state to test that module.  `make help` will enumerate more targets and instructions
+
+### README.md
+
+Presently reading.  Enjoy
 
 ## Building and Testing
 
 If you want to make tests, the first thing you'll likely need to do is `make utils` to make the bramGen programs.  Then `make bram` will create a build directory and a bram subdirectory in it so that tests can launch.  **IMPORTANT:** your hex files must have at least as many entries as tests are built to expect or the test will fail.  It is best to have these numbers equal, and this is controlled by the `TEST_COUNT` variable in the Top level Makefile.  It is recommended to alter that value in the makefile itself.  `make ModuleTb` will generate a testbench with a module that can execute all the B extension operations except ANDC (will be relegated to RISCV_BBox).
 
 Building individual instruction tests can be done with the `[INSN]Tb` target or `test-all` target.  **IMPORTANT:** This will build from the archive directory only.  Tests can be launched via the `launch-[INSN]` target.
+
+_This section could use a bit of an update.  `make help` hopefully covers everything here, but better to be overly verbose here._
 
 ## Dependencies
 
@@ -25,8 +51,8 @@ Building individual instruction tests can be done with the `[INSN]Tb` target or 
 
 ## Checklist
 
-1. Make a 64 bit compliant BitManipIter Module
-2. Build the RISCV_BBox
-3. Incorporate into Piccolo or Flute
-4. Tabular test results (Issue exists)
-5. Fixed Latency Modules
+1. Build the RISCV_BBox
+2. Incorporate into Piccolo or Flute
+3. Tabular test results (Issue exists)
+4. Fixed Latency Modules
+5. Fixed Latency Pipelined Modules

--- a/bsv/BitManipIter.bsv
+++ b/bsv/BitManipIter.bsv
@@ -198,7 +198,7 @@ module mkBitManipIter (BitManip_IFC);
       $display("   control    -- %h", rg_control);
       $display("   seed       -- %h", rg_seed);
       $display("   setter     -- %h", rg_setter);
-      $display("   terminating - %b", terminate_Left_shift);
+      $display("   terminating - %b", terminate_left_shift);
       rg_cycle <= rg_cycle + 1;
     `endif
     if (terminate_left_shift) rg_state <= S_Idle;

--- a/bsv/BitManipIter.bsv
+++ b/bsv/BitManipIter.bsv
@@ -28,29 +28,6 @@ import BitManipMeta :: *;
 //                                             //
 /////////////////////////////////////////////////
 
-function IterState fv_state_init(BitManipOp op);
-  case(op) matches
-    CLZ      : return S_Calc;
-    CTZ      : return S_Calc;
-    PCNT     : return S_Calc;
-    SRO      : return S_Calc;
-    SLO      : return S_Calc;
-    ROR      : return S_Calc;
-    ROL      : return S_Calc;
-    GREV     : return S_Stage_1;
-    `ifdef RV32  // this shuffle portion will likely get messy...
-    SHFL     : return S_Stage_8;
-    `elsif RV64
-    SHFL     : return S_Stage_16;
-    `endif
-    UNSHFL   : return S_Stage_1;
-    BEXT     : return S_Calc;
-    BDEP     : return S_Calc;
-    ANDC     : return S_Idle; // andc not managed here
-    default  : return S_Idle;
-  endcase
-endfunction: fv_state_init
-
 module mkBitManipIter (BitManip_IFC);
 
   Reg #(BitXL)      rg_res       <- mkRegU;  // we'll accumulate a result here

--- a/bsv/BitManipIter.bsv
+++ b/bsv/BitManipIter.bsv
@@ -134,8 +134,6 @@ module mkBitManipIter (BitManip_IFC);
   Bool terminate_bext_bdep   = exit_bext_bdep     && ((rg_operation == BEXT) || 
                                                       (rg_operation == BDEP));
 
-  Bool result_valid          = terminate_right_shift || terminate_left_shift || terminate_grev ||
-                               terminate_shfl        || terminate_bext_bdep;
   /////////////////////////
   //                     //
   // Rules               //
@@ -345,10 +343,11 @@ module mkBitManipIter (BitManip_IFC);
                          `endif
                           ) if (rg_state == S_Idle);
 
-    let res_init     = fv_result_init  (op_sel, arg0);
     `ifdef RV32
+    let res_init     = fv_result_init  (op_sel, arg0);
     let control_init = fv_control_init (op_sel, arg0, arg1);
     `elsif RV64
+    let res_init     = fv_result_init  (op_sel, arg0, is_32bit);
     let control_init = fv_control_init (op_sel, arg0, arg1, is_32bit);
     `endif
 

--- a/bsv/BitManipIter.bsv
+++ b/bsv/BitManipIter.bsv
@@ -345,13 +345,16 @@ module mkBitManipIter (BitManip_IFC);
                          `endif
                           ) if (rg_state == S_Idle);
 
-    rg_res     <= fv_result_init  (op_sel, arg0);
+    let res_init     = fv_result_init  (op_sel, arg0);
     `ifdef RV32
-    rg_control <= fv_control_init (op_sel, arg0, arg1);
-    `elsif
-    rg_control <= fv_control_init (op_sel, arg0, arg1, is_32bit);
+    let control_init = fv_control_init (op_sel, arg0, arg1);
+    `elsif RV64
+    let control_init = fv_control_init (op_sel, arg0, arg1, is_32bit);
     `endif
 
+    rg_res     <= res_init; 
+    rg_control <= control_init;
+ 
     // assigning the below in a slightly sloppy fashion since
     // only the pack operations utilize them (grev uses seed)
     rg_seed     <= 1;
@@ -366,6 +369,21 @@ module mkBitManipIter (BitManip_IFC);
 
     `ifdef HW_DIAG
     rg_cycle     <= 0;  // init for diagnostic build
+    $display("--------------------------------------");
+    $display("   BitManipIter Arg Put               ");
+    $display("   Operation: ", fshow(op_sel));
+    `ifdef RV64
+    if(!is_32bit)
+      $display("   64 bit mode ");
+    else
+      $display("   32 bit mode ");
+    $display(" ");
+    $display("     Res     init : %h", res_init);
+    $display("     Control init : %h", control_init);
+    $display("     Seed always inits to 1");
+    $display("     Setter  init : %h", arg0);
+    $display("--------------------------------------");
+    `endif
     `endif
 
   endmethod: args_put

--- a/bsv/BitManipMeta.bsv
+++ b/bsv/BitManipMeta.bsv
@@ -213,14 +213,22 @@ endinterface: BitManip_IFC
 
 // functions to set registers in the modules on args_put
 // question: put these in BitManipIter.bsv???
-function BitXL fv_result_init (BitManipOp op, BitXL arg0);
+function BitXL fv_result_init (BitManipOp op,
+                               BitXL arg0
+                               `ifdef RV64
+                               ,Bool is_32_bit
+                               `endif
+                               );
+
   `ifdef RV32
-  let is_zero_init = (op == CLZ)  || (op == CTZ)  || (op == PCNT)  || (op == BEXT)  || (op == BDEP);  
+    let is_zero_init = (op == CLZ)  || (op == CTZ)  || (op == PCNT)  || (op == BEXT)  || (op == BDEP);  
+    return (is_zero_init) ? 0 : arg0; // not super worried about how andc behaves here...
   `elsif RV64
-  let is_zero_init = (op == CLZ)  || (op == CTZ)  || (op == PCNT)  || (op == BEXT)  || (op == BDEP) ||
-                      (op == CLZW) || (op == CTZW) || (op == PCNTW) || (op == BEXTW) || (op == BDEPW) ;  
+    let is_zero_init = (op == CLZ)  || (op == CTZ)  || (op == PCNT)  || (op == BEXT)  || (op == BDEP) ||
+                       (op == CLZW) || (op == CTZW) || (op == PCNTW) || (op == BEXTW) || (op == BDEPW) ;  
+    return (is_zero_init) ? 0 : (is_32_bit) ? (arg0 & lower_32) : arg0;
   `endif
-  return (is_zero_init) ? 0 : arg0; // not super worried about how andc behaves here...
+
 endfunction: fv_result_init
 
 `ifdef RV64

--- a/bsv/BitManipMeta.bsv
+++ b/bsv/BitManipMeta.bsv
@@ -260,8 +260,8 @@ function BitXL fv_control_init (BitManipOp op,
       ROR     : return arg1[(log_xlen - 1) : 0];
       ROL     : return arg1[(log_xlen - 1) : 0];
       GREV    : return arg1[(log_xlen - 1) : 0];
-      SHFL    : return reverseBits(arg1) >> (xlen - 4);   
-      UNSHFL  : return arg1[(log_xlen - 2) : 0];
+      SHFL    : return reverseBits(arg1) >> (xlen - 4);  // need - 5 in RV64 
+      UNSHFL  : return arg1[(log_xlen - 2) : 0];         // how to generalize??
       BEXT    : return arg1;
       BDEP    : return arg1;
       default : return 0; // expecting andc, want this to be poor behaving

--- a/bsv/BitManipMeta.bsv
+++ b/bsv/BitManipMeta.bsv
@@ -225,4 +225,27 @@ function BitXL fv_control_init (BitManipOp op, BitXL arg0, BitXL arg1);
   endcase
 endfunction
 
+function IterState fv_state_init(BitManipOp op);
+  case(op) matches
+    CLZ      : return S_Calc;
+    CTZ      : return S_Calc;
+    PCNT     : return S_Calc;
+    SRO      : return S_Calc;
+    SLO      : return S_Calc;
+    ROR      : return S_Calc;
+    ROL      : return S_Calc;
+    GREV     : return S_Stage_1;
+    `ifdef RV32  // this shuffle portion will likely get messy...
+    SHFL     : return S_Stage_8;
+    `elsif RV64
+    SHFL     : return S_Stage_16;
+    `endif
+    UNSHFL   : return S_Stage_1;
+    BEXT     : return S_Calc;
+    BDEP     : return S_Calc;
+    ANDC     : return S_Idle; // andc not managed here
+    default  : return S_Idle;
+  endcase
+endfunction: fv_state_init
+
 endpackage: BitManipMeta

--- a/bsv/BitManipMeta.bsv
+++ b/bsv/BitManipMeta.bsv
@@ -175,17 +175,6 @@ typedef enum {CLZ,
               UNSHFL,
               BEXT,
               BDEP,
-              `ifdef RV64
-              CLZW,
-              CTZW,
-              PCNTW,
-              SROW,
-              SLOW,
-              RORW,
-              ROLW,
-              BEXTW,
-              BDEPW,
-              `endif
               ANDC} BitManipOp deriving (Eq, Bits, FShow);
 
 /////////////////////////////////////////////////
@@ -220,12 +209,10 @@ function BitXL fv_result_init (BitManipOp op,
                                `endif
                                );
 
-  `ifdef RV32
     let is_zero_init = (op == CLZ)  || (op == CTZ)  || (op == PCNT)  || (op == BEXT)  || (op == BDEP);  
+  `ifdef RV32
     return (is_zero_init) ? 0 : arg0; // not super worried about how andc behaves here...
   `elsif RV64
-    let is_zero_init = (op == CLZ)  || (op == CTZ)  || (op == PCNT)  || (op == BEXT)  || (op == BDEP) ||
-                       (op == CLZW) || (op == CTZW) || (op == PCNTW) || (op == BEXTW) || (op == BDEPW) ;  
     return (is_zero_init) ? 0 : (is_32_bit) ? (arg0 & lower_32) : arg0;
   `endif
 

--- a/bsv/BitManipMeta.bsv
+++ b/bsv/BitManipMeta.bsv
@@ -282,7 +282,11 @@ function BitXL fv_control_init (BitManipOp op,
   `endif
 endfunction
 
-function IterState fv_state_init(BitManipOp op);
+function IterState fv_state_init(BitManipOp op
+                                 `ifdef RV64
+                                 ,Bool is_32_bit
+                                 `endif
+                                 );
   case(op) matches
     CLZ      : return S_Calc;
     CTZ      : return S_Calc;
@@ -292,10 +296,10 @@ function IterState fv_state_init(BitManipOp op);
     ROR      : return S_Calc;
     ROL      : return S_Calc;
     GREV     : return S_Stage_1;
-    `ifdef RV32  // this shuffle portion will likely get messy...
+    `ifdef RV32  
     SHFL     : return S_Stage_8;
     `elsif RV64
-    SHFL     : return S_Stage_16;
+    SHFL     : return (is_32_bit) ? S_Stage_8 : S_Stage_16;
     `endif
     UNSHFL   : return S_Stage_1;
     BEXT     : return S_Calc;

--- a/bsv/BitManipMeta.bsv
+++ b/bsv/BitManipMeta.bsv
@@ -235,7 +235,7 @@ function BitXL fv_control_init (BitManipOp op,
                                 `endif
                                 );
   `ifdef RV64
-  if(is_32_bit) begin  // "W" operations
+  if(is_32_bit) begin
     case (op) matches
       CLZ     : return reverseBits(arg0) >> 32;
       CTZ     : return arg0 & lower_32;
@@ -244,9 +244,12 @@ function BitXL fv_control_init (BitManipOp op,
       SLO     : return arg1[(log_xlen - 2) : 0];
       ROR     : return arg1[(log_xlen - 2) : 0];
       ROL     : return arg1[(log_xlen - 2) : 0];
+      GREV    : return arg1[(log_xlen - 2) : 0];
+      SHFL    : return reverseBits(arg1) >> (xlen - 4);
+      UNSHFL  : return arg1[(log_xlen - 2) : 0];       
       BEXT    : return arg1 & lower_32;
       BDEP    : return arg1 & lower_32;
-      default : return 0; // expecting andc, want this to be poor behaving
+      default : return 0;
     endcase
   end
   else begin
@@ -260,8 +263,8 @@ function BitXL fv_control_init (BitManipOp op,
       ROR     : return arg1[(log_xlen - 1) : 0];
       ROL     : return arg1[(log_xlen - 1) : 0];
       GREV    : return arg1[(log_xlen - 1) : 0];
-      SHFL    : return reverseBits(arg1) >> (xlen - 4);  // need - 5 in RV64 
-      UNSHFL  : return arg1[(log_xlen - 2) : 0];         // how to generalize??
+      SHFL    : return reverseBits(arg1) >> (xlen - (log_xlen - 1));
+      UNSHFL  : return arg1[(log_xlen - 2) : 0];
       BEXT    : return arg1;
       BDEP    : return arg1;
       default : return 0; // expecting andc, want this to be poor behaving

--- a/bsv/Makefile
+++ b/bsv/Makefile
@@ -10,6 +10,7 @@ XLEN        ?= 32
 TEST_COUNT  ?= 16
 #TEST_VERBOSE = on
 #HW_DIAG      = on
+#TB_HARD_FAIL = on
 
 BSC ?= bsc
 
@@ -22,6 +23,9 @@ BLUESIM_DEFINES += -D TEST_VERBOSE
 endif
 ifdef HW_DIAG
 BLUESIM_DEFINES += -D HW_DIAG
+endif
+ifdef TB_HARD_FAIL
+BLUESIM_DEFINES += -D TB_HARD_FAIL
 endif
 
 BLUESIM_S1 = -u -sim

--- a/bsv/ModuleTb.bsv
+++ b/bsv/ModuleTb.bsv
@@ -43,25 +43,10 @@ function BitManipOp fv_nextOp(BitManipOp op);
     BDEP    : return ANDC;
     `else 
     BDEP    : return CLZ;//W;
-/*    CLZW    : return CTZW;
-    CTZW    : return PCNTW;
-    PCNTW   : return SROW;
-    SROW    : return SLOW;
-    SLOW    : return RORW;
-    RORW    : return ROLW;
-    ROLW    : return BEXTW;
-    BEXTW   : return BDEPW;
-    BDEPW   : return ANDC;*/
     `endif
     default : return CLZ; // ensures we kickoff in CLZ
   endcase
 endfunction: fv_nextOp
-
-`ifdef RV32
-BitManipOp final_operation = BDEP;
-`elsif RV64
-BitManipOp final_operation = BDEPW;
-`endif
 
 typedef enum {Op_Init,
               Mem_Init,

--- a/bsv/ModuleTb.bsv
+++ b/bsv/ModuleTb.bsv
@@ -106,15 +106,18 @@ module mkModuleTb (Empty);
   BRAM_PORT #(BramEntry, BitXL) bdep   <- mkBRAMCore1Load(bram_entries, False, bdep_file  , False);
 
   `ifdef RV64
-  BRAM_PORT #(BramEntry, BitXL) clz32  <- mkBRAMCore1Load(bram_entries, False, clzw_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) ctz32  <- mkBRAMCore1Load(bram_entries, False, ctzw_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) pcnt32 <- mkBRAMCore1Load(bram_entries, False, pcntw_file , False);
-  BRAM_PORT #(BramEntry, BitXL) sro32  <- mkBRAMCore1Load(bram_entries, False, srow_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) slo32  <- mkBRAMCore1Load(bram_entries, False, slow_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) ror32  <- mkBRAMCore1Load(bram_entries, False, rorw_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) rol32  <- mkBRAMCore1Load(bram_entries, False, rolw_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) bext32 <- mkBRAMCore1Load(bram_entries, False, bextw_file , False);
-  BRAM_PORT #(BramEntry, BitXL) bdep32 <- mkBRAMCore1Load(bram_entries, False, bdepw_file , False);
+  BRAM_PORT #(BramEntry, BitXL) clz32    <- mkBRAMCore1Load(bram_entries, False, clz32_file   , False);
+  BRAM_PORT #(BramEntry, BitXL) ctz32    <- mkBRAMCore1Load(bram_entries, False, ctz32_file   , False);
+  BRAM_PORT #(BramEntry, BitXL) pcnt32   <- mkBRAMCore1Load(bram_entries, False, pcnt32_file  , False);
+  BRAM_PORT #(BramEntry, BitXL) sro32    <- mkBRAMCore1Load(bram_entries, False, sro32_file   , False);
+  BRAM_PORT #(BramEntry, BitXL) slo32    <- mkBRAMCore1Load(bram_entries, False, slo32_file   , False);
+  BRAM_PORT #(BramEntry, BitXL) ror32    <- mkBRAMCore1Load(bram_entries, False, ror32_file   , False);
+  BRAM_PORT #(BramEntry, BitXL) rol32    <- mkBRAMCore1Load(bram_entries, False, rol32_file   , False);
+  BRAM_PORT #(BramEntry, BitXL) grev32   <- mkBRAMCore1Load(bram_entries, False, grev32_file  , False);
+  BRAM_PORT #(BramEntry, BitXL) shfl32   <- mkBRAMCore1Load(bram_entries, False, shfl32_file  , False);
+  BRAM_PORT #(BramEntry, BitXL) unshfl32 <- mkBRAMCore1Load(bram_entries, False, unshfl32_file, False);
+  BRAM_PORT #(BramEntry, BitXL) bext32   <- mkBRAMCore1Load(bram_entries, False, bext32_file  , False);
+  BRAM_PORT #(BramEntry, BitXL) bdep32   <- mkBRAMCore1Load(bram_entries, False, bdep32_file  , False);
   `endif
 
   BitManip_IFC dut <- mkBitManipIter;
@@ -172,34 +175,21 @@ module mkModuleTb (Empty);
     end
     else begin
       case (rg_operation) matches
-        CLZ    : clz32.put  (False, rg_bram_offset, 0);
-        CTZ    : ctz32.put  (False, rg_bram_offset, 0);
-        PCNT   : pcnt32.put (False, rg_bram_offset, 0);
-        SRO    : sro32.put  (False, rg_bram_offset, 0);
-        SLO    : slo32.put  (False, rg_bram_offset, 0);
-        ROR    : ror32.put  (False, rg_bram_offset, 0);
-        ROL    : rol32.put  (False, rg_bram_offset, 0);
-//        GREV   : grev.put   (False, rg_bram_offset, 0);  // no W insn, but should still test
-//        SHFL   : shfl.put   (False, rg_bram_offset, 0);  // in case we can run a 32 bit mode
-//        UNSHFL : unshfl.put (False, rg_bram_offset, 0);  // in a RV64 proc??
-        BEXT   : bext32.put (False, rg_bram_offset, 0);
-        BDEP   : bdep32.put (False, rg_bram_offset, 0);
+        CLZ    : clz32.put    (False, rg_bram_offset, 0);
+        CTZ    : ctz32.put    (False, rg_bram_offset, 0);
+        PCNT   : pcnt32.put   (False, rg_bram_offset, 0);
+        SRO    : sro32.put    (False, rg_bram_offset, 0);
+        SLO    : slo32.put    (False, rg_bram_offset, 0);
+        ROR    : ror32.put    (False, rg_bram_offset, 0);
+        ROL    : rol32.put    (False, rg_bram_offset, 0);
+        GREV   : grev32.put   (False, rg_bram_offset, 0);  // no W insn, but should still test
+        SHFL   : shfl32.put   (False, rg_bram_offset, 0);  // in case we can run a 32 bit mode
+        UNSHFL : unshfl32.put (False, rg_bram_offset, 0);  // in a RV64 proc??
+        BEXT   : bext32.put   (False, rg_bram_offset, 0);
+        BDEP   : bdep32.put   (False, rg_bram_offset, 0);
       endcase
     end
     `endif
-
-/*      `ifdef RV64
-      CLZW   : clzw.put   (False, rg_bram_offset, 0);
-      CTZW   : ctzw.put   (False, rg_bram_offset, 0);
-      PCNTW  : pcntw.put  (False, rg_bram_offset, 0);
-      SROW   : srow.put   (False, rg_bram_offset, 0);
-      SLOW   : slow.put   (False, rg_bram_offset, 0);
-      RORW   : rorw.put   (False, rg_bram_offset, 0);
-      ROLW   : rolw.put   (False, rg_bram_offset, 0);
-      BEXTW  : bextw.put  (False, rg_bram_offset, 0);
-      BDEPW  : bdepw.put  (False, rg_bram_offset, 0);
-      `endif
-    endcase */
 
     rg_state <= Dut_Init;
   endrule: tb_mem_init
@@ -229,18 +219,19 @@ module mkModuleTb (Empty);
               (rg_operation == BDEP)   ? bdep.read   :
               0;
     `elsif RV64
-    let res = ((rg_operation == CLZ)    && (!rg_32_bit)) ? clz.read    :
-              ((rg_operation == CTZ)    && (!rg_32_bit)) ? ctz.read    :
-              ((rg_operation == PCNT)   && (!rg_32_bit)) ? pcnt.read   :
-              ((rg_operation == SRO)    && (!rg_32_bit)) ? sro.read    :
-              ((rg_operation == SLO)    && (!rg_32_bit)) ? slo.read    :
-              ((rg_operation == ROR)    && (!rg_32_bit)) ? ror.read    :
-              ((rg_operation == ROL)    && (!rg_32_bit)) ? rol.read    :
-              ((rg_operation == GREV)   && (!rg_32_bit)) ? grev.read   :
-              ((rg_operation == SHFL)   && (!rg_32_bit)) ? shfl.read   :
-              ((rg_operation == UNSHFL) && (!rg_32_bit)) ? unshfl.read :
-              ((rg_operation == BEXT)   && (!rg_32_bit)) ? bext.read   :
-              ((rg_operation == BDEP)   && (!rg_32_bit)) ? bdep.read   :
+    let res = ((rg_operation == CLZ)    && (!rg_32_bit)) ? clz.read      :
+              ((rg_operation == CTZ)    && (!rg_32_bit)) ? ctz.read      :
+              ((rg_operation == PCNT)   && (!rg_32_bit)) ? pcnt.read     :
+              ((rg_operation == SRO)    && (!rg_32_bit)) ? sro.read      :
+              ((rg_operation == SLO)    && (!rg_32_bit)) ? slo.read      :
+              ((rg_operation == ROR)    && (!rg_32_bit)) ? ror.read      :
+              ((rg_operation == ROL)    && (!rg_32_bit)) ? rol.read      :
+              ((rg_operation == GREV)   && (!rg_32_bit)) ? grev.read     :
+              ((rg_operation == SHFL)   && (!rg_32_bit)) ? shfl.read     :
+              ((rg_operation == UNSHFL) && (!rg_32_bit)) ? unshfl.read   :
+              ((rg_operation == BEXT)   && (!rg_32_bit)) ? bext.read     :
+              ((rg_operation == BDEP)   && (!rg_32_bit)) ? bdep.read     :
+              //  64 bit above              32 bit below
               ((rg_operation == CLZ)    &&  (rg_32_bit)) ? clz32.read    :
               ((rg_operation == CTZ)    &&  (rg_32_bit)) ? ctz32.read    :
               ((rg_operation == PCNT)   &&  (rg_32_bit)) ? pcnt32.read   :
@@ -248,9 +239,9 @@ module mkModuleTb (Empty);
               ((rg_operation == SLO)    &&  (rg_32_bit)) ? slo32.read    :
               ((rg_operation == ROR)    &&  (rg_32_bit)) ? ror32.read    :
               ((rg_operation == ROL)    &&  (rg_32_bit)) ? rol32.read    :
-//              ((rg_operation == GREV)   &&  (rg_32_bit)) ? grev.read   :
-//              ((rg_operation == SHFL)   &&  (rg_32_bit)) ? shfl.read   :
-//              ((rg_operation == UNSHFL) &&  (rg_32_bit)) ? unshfl.read :
+              ((rg_operation == GREV)   &&  (rg_32_bit)) ? grev32.read   :
+              ((rg_operation == SHFL)   &&  (rg_32_bit)) ? shfl32.read   :
+              ((rg_operation == UNSHFL) &&  (rg_32_bit)) ? unshfl32.read :
               ((rg_operation == BEXT)   &&  (rg_32_bit)) ? bext32.read   :
               ((rg_operation == BDEP)   &&  (rg_32_bit)) ? bdep32.read   :
               0;
@@ -278,12 +269,7 @@ module mkModuleTb (Empty);
     end
   endrule: tb_dut_wait
 
-//  `ifdef RV32
   Bool rs2_useful = !((rg_operation == CLZ)  || (rg_operation == CTZ)  || (rg_operation == PCNT));
-//  `elsif RV64
-//  Bool rs2_useful = !((rg_operation == CLZ)  || (rg_operation == CTZ)  || (rg_operation == PCNT) ||
-//                      (rg_operation == CLZW) || (rg_operation == CTZW) || (rg_operation == PCNTW));
-//  `endif
 
   `ifdef RV32
   Bool inc_op = rg_operation != BDEP;

--- a/bsv/ModuleTb.bsv
+++ b/bsv/ModuleTb.bsv
@@ -68,6 +68,9 @@ typedef enum {Op_Init,
               Dut_Init,
               Dut_Wait,
               Dut_Return,
+              `ifdef TB_HARD_FAIL
+              Tb_Hard_Fail,
+              `endif
               Tb_Exit} TbState deriving (Eq, Bits, FShow);
 
 (* synthesize *)
@@ -259,6 +262,10 @@ module mkModuleTb (Empty);
     
     rg_bram_offset <= rg_bram_offset + 1;
 
+    `ifdef TB_HARD_FAIL
+    if(fail) rg_state <= Tb_Hard_Fail;
+    else
+    `endif
     if (rg_bram_offset != fromInteger(bram_limit)) rg_state <= Mem_Init;
     else if (rg_operation != final_operation)      rg_state <= Op_Init;
     else                                           rg_state <= Tb_Exit;
@@ -273,6 +280,13 @@ module mkModuleTb (Empty);
     $finish(0);
   endrule: tb_exit
 
+
+  `ifdef TB_HARD_FAIL
+  rule tb_hard_fail (rg_state == Tb_Hard_Fail);
+    $display("--- Exiting on Failure ---");
+    $finish(0);
+  endrule: tb_hard_fail
+  `endif
 
 
 endmodule: mkModuleTb

--- a/bsv/ModuleTb.bsv
+++ b/bsv/ModuleTb.bsv
@@ -41,7 +41,7 @@ function BitManipOp fv_nextOp(BitManipOp op);
     BEXT    : return BDEP;
     `ifdef RV32
     BDEP    : return ANDC;
-    `elsif 
+    `else 
     BDEP    : return CLZW;
     CLZW    : return CTZW;
     CTZW    : return PCNTW;

--- a/bsv/ModuleTb.bsv
+++ b/bsv/ModuleTb.bsv
@@ -212,10 +212,11 @@ module mkModuleTb (Empty);
 
     dut.args_put(arg0,
                  arg1,
+                 rg_operation
                  `ifdef RV64
-                 rg_32_bit,
+                 ,rg_32_bit
                  `endif
-                 rg_operation);
+                 );
 
     rg_state <= Dut_Wait;
   endrule: tb_dut_init

--- a/bsv/ModuleTb.bsv
+++ b/bsv/ModuleTb.bsv
@@ -125,14 +125,10 @@ module mkModuleTb (Empty);
   rule tb_op_init (rg_state == Op_Init);
     `ifdef TEST_VERBOSE
     $display("----- Begin Tests for ", fshow(fv_nextOp(rg_operation)));
-    `ifdef RV64
-    if(rg_32_bit) $display("----- 32 bit mode -----");
-    else          $display("----- 64 bit mode -----");
-    `endif
     `endif 
 
     rg_operation <= fv_nextOp(rg_operation);
-    `ifdef
+    `ifdef RV64
     rg_32_bit    <= (rg_operation == BDEP) ? True : False;
     `endif
     rg_state     <= Mem_Init;
@@ -143,6 +139,10 @@ module mkModuleTb (Empty);
   rule tb_mem_init (rg_state == Mem_Init);
     `ifdef TEST_VERBOSE
     $display("Test %d of %d", rg_bram_offset, fromInteger(bram_limit));
+    `ifdef RV64
+    if(rg_32_bit) $display("32 bit");
+    else          $display("64 bit");
+    `endif
     `endif
 
     rs1.put   (False, rg_bram_offset, 0);

--- a/bsv/ModuleTb.bsv
+++ b/bsv/ModuleTb.bsv
@@ -125,6 +125,10 @@ module mkModuleTb (Empty);
   rule tb_op_init (rg_state == Op_Init);
     `ifdef TEST_VERBOSE
     $display("----- Begin Tests for ", fshow(fv_nextOp(rg_operation)));
+    `ifdef RV64
+    if(rg_32_bit) $display("----- 32 bit mode -----");
+    else          $display("----- 64 bit mode -----");
+    `endif
     `endif 
 
     rg_operation <= fv_nextOp(rg_operation);

--- a/bsv/ModuleTb.bsv
+++ b/bsv/ModuleTb.bsv
@@ -42,8 +42,8 @@ function BitManipOp fv_nextOp(BitManipOp op);
     `ifdef RV32
     BDEP    : return ANDC;
     `else 
-    BDEP    : return CLZW;
-    CLZW    : return CTZW;
+    BDEP    : return CLZ;//W;
+/*    CLZW    : return CTZW;
     CTZW    : return PCNTW;
     PCNTW   : return SROW;
     SROW    : return SLOW;
@@ -51,7 +51,7 @@ function BitManipOp fv_nextOp(BitManipOp op);
     RORW    : return ROLW;
     ROLW    : return BEXTW;
     BEXTW   : return BDEPW;
-    BDEPW   : return ANDC;
+    BDEPW   : return ANDC;*/
     `endif
     default : return CLZ; // ensures we kickoff in CLZ
   endcase
@@ -106,15 +106,15 @@ module mkModuleTb (Empty);
   BRAM_PORT #(BramEntry, BitXL) bdep   <- mkBRAMCore1Load(bram_entries, False, bdep_file  , False);
 
   `ifdef RV64
-  BRAM_PORT #(BramEntry, BitXL) clzw   <- mkBRAMCore1Load(bram_entries, False, clzw_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) ctzw   <- mkBRAMCore1Load(bram_entries, False, ctzw_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) pcntw  <- mkBRAMCore1Load(bram_entries, False, pcntw_file , False);
-  BRAM_PORT #(BramEntry, BitXL) srow   <- mkBRAMCore1Load(bram_entries, False, srow_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) slow   <- mkBRAMCore1Load(bram_entries, False, slow_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) rorw   <- mkBRAMCore1Load(bram_entries, False, rorw_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) rolw   <- mkBRAMCore1Load(bram_entries, False, rolw_file  , False);
-  BRAM_PORT #(BramEntry, BitXL) bextw  <- mkBRAMCore1Load(bram_entries, False, bextw_file , False);
-  BRAM_PORT #(BramEntry, BitXL) bdepw  <- mkBRAMCore1Load(bram_entries, False, bdepw_file , False);
+  BRAM_PORT #(BramEntry, BitXL) clz32  <- mkBRAMCore1Load(bram_entries, False, clzw_file  , False);
+  BRAM_PORT #(BramEntry, BitXL) ctz32  <- mkBRAMCore1Load(bram_entries, False, ctzw_file  , False);
+  BRAM_PORT #(BramEntry, BitXL) pcnt32 <- mkBRAMCore1Load(bram_entries, False, pcntw_file , False);
+  BRAM_PORT #(BramEntry, BitXL) sro32  <- mkBRAMCore1Load(bram_entries, False, srow_file  , False);
+  BRAM_PORT #(BramEntry, BitXL) slo32  <- mkBRAMCore1Load(bram_entries, False, slow_file  , False);
+  BRAM_PORT #(BramEntry, BitXL) ror32  <- mkBRAMCore1Load(bram_entries, False, rorw_file  , False);
+  BRAM_PORT #(BramEntry, BitXL) rol32  <- mkBRAMCore1Load(bram_entries, False, rolw_file  , False);
+  BRAM_PORT #(BramEntry, BitXL) bext32 <- mkBRAMCore1Load(bram_entries, False, bextw_file , False);
+  BRAM_PORT #(BramEntry, BitXL) bdep32 <- mkBRAMCore1Load(bram_entries, False, bdepw_file , False);
   `endif
 
   BitManip_IFC dut <- mkBitManipIter;
@@ -132,7 +132,7 @@ module mkModuleTb (Empty);
 
     rg_operation <= fv_nextOp(rg_operation);
     `ifdef RV64
-    rg_32_bit    <= (rg_operation == BDEP) ? True : False;
+    rg_32_bit    <= (rg_operation == BDEP) ? True : rg_32_bit;
     `endif
     rg_state     <= Mem_Init;
   endrule: tb_op_init
@@ -151,20 +151,44 @@ module mkModuleTb (Empty);
     rs1.put   (False, rg_bram_offset, 0);
     rs2.put   (False, rg_bram_offset, 0);
 
-    case (rg_operation) matches
-      CLZ    : clz.put    (False, rg_bram_offset, 0);
-      CTZ    : ctz.put    (False, rg_bram_offset, 0);
-      PCNT   : pcnt.put   (False, rg_bram_offset, 0);
-      SRO    : sro.put    (False, rg_bram_offset, 0);
-      SLO    : slo.put    (False, rg_bram_offset, 0);
-      ROR    : ror.put    (False, rg_bram_offset, 0);
-      ROL    : rol.put    (False, rg_bram_offset, 0);
-      GREV   : grev.put   (False, rg_bram_offset, 0);
-      SHFL   : shfl.put   (False, rg_bram_offset, 0);
-      UNSHFL : unshfl.put (False, rg_bram_offset, 0);
-      BEXT   : bext.put   (False, rg_bram_offset, 0);
-      BDEP   : bdep.put   (False, rg_bram_offset, 0);
-      `ifdef RV64
+    `ifdef RV64
+    if(!rg_32_bit) begin
+    `endif
+      case (rg_operation) matches
+        CLZ    : clz.put    (False, rg_bram_offset, 0);
+        CTZ    : ctz.put    (False, rg_bram_offset, 0);
+        PCNT   : pcnt.put   (False, rg_bram_offset, 0);
+        SRO    : sro.put    (False, rg_bram_offset, 0);
+        SLO    : slo.put    (False, rg_bram_offset, 0);
+        ROR    : ror.put    (False, rg_bram_offset, 0);
+        ROL    : rol.put    (False, rg_bram_offset, 0);
+        GREV   : grev.put   (False, rg_bram_offset, 0);
+        SHFL   : shfl.put   (False, rg_bram_offset, 0);
+        UNSHFL : unshfl.put (False, rg_bram_offset, 0);
+        BEXT   : bext.put   (False, rg_bram_offset, 0);
+        BDEP   : bdep.put   (False, rg_bram_offset, 0);
+      endcase
+    `ifdef RV64
+    end
+    else begin
+      case (rg_operation) matches
+        CLZ    : clz32.put  (False, rg_bram_offset, 0);
+        CTZ    : ctz32.put  (False, rg_bram_offset, 0);
+        PCNT   : pcnt32.put (False, rg_bram_offset, 0);
+        SRO    : sro32.put  (False, rg_bram_offset, 0);
+        SLO    : slo32.put  (False, rg_bram_offset, 0);
+        ROR    : ror32.put  (False, rg_bram_offset, 0);
+        ROL    : rol32.put  (False, rg_bram_offset, 0);
+//        GREV   : grev.put   (False, rg_bram_offset, 0);  // no W insn, but should still test
+//        SHFL   : shfl.put   (False, rg_bram_offset, 0);  // in case we can run a 32 bit mode
+//        UNSHFL : unshfl.put (False, rg_bram_offset, 0);  // in a RV64 proc??
+        BEXT   : bext32.put (False, rg_bram_offset, 0);
+        BDEP   : bdep32.put (False, rg_bram_offset, 0);
+      endcase
+    end
+    `endif
+
+/*      `ifdef RV64
       CLZW   : clzw.put   (False, rg_bram_offset, 0);
       CTZW   : ctzw.put   (False, rg_bram_offset, 0);
       PCNTW  : pcntw.put  (False, rg_bram_offset, 0);
@@ -175,7 +199,7 @@ module mkModuleTb (Empty);
       BEXTW  : bextw.put  (False, rg_bram_offset, 0);
       BDEPW  : bdepw.put  (False, rg_bram_offset, 0);
       `endif
-    endcase
+    endcase */
 
     rg_state <= Dut_Init;
   endrule: tb_mem_init
@@ -190,6 +214,7 @@ module mkModuleTb (Empty);
     rg_rs1 <= arg0;
     rg_rs2 <= arg1;
 
+    `ifdef RV32
     let res = (rg_operation == CLZ)    ? clz.read    :
               (rg_operation == CTZ)    ? ctz.read    :
               (rg_operation == PCNT)   ? pcnt.read   :
@@ -202,18 +227,34 @@ module mkModuleTb (Empty);
               (rg_operation == UNSHFL) ? unshfl.read :
               (rg_operation == BEXT)   ? bext.read   :
               (rg_operation == BDEP)   ? bdep.read   :
-              `ifdef RV64
-              (rg_operation == CLZW)   ? clzw.read   :
-              (rg_operation == CTZW)   ? ctzw.read   :
-              (rg_operation == PCNTW)  ? pcntw.read  :
-              (rg_operation == SROW)   ? srow.read   :
-              (rg_operation == SLOW)   ? slow.read   :
-              (rg_operation == RORW)   ? rorw.read   :
-              (rg_operation == ROLW)   ? rolw.read   :
-              (rg_operation == BEXTW)  ? bextw.read  :
-              (rg_operation == BDEPW)  ? bdepw.read  :
-              `endif
-              0; 
+              0;
+    `elsif RV64
+    let res = ((rg_operation == CLZ)    && (!rg_32_bit)) ? clz.read    :
+              ((rg_operation == CTZ)    && (!rg_32_bit)) ? ctz.read    :
+              ((rg_operation == PCNT)   && (!rg_32_bit)) ? pcnt.read   :
+              ((rg_operation == SRO)    && (!rg_32_bit)) ? sro.read    :
+              ((rg_operation == SLO)    && (!rg_32_bit)) ? slo.read    :
+              ((rg_operation == ROR)    && (!rg_32_bit)) ? ror.read    :
+              ((rg_operation == ROL)    && (!rg_32_bit)) ? rol.read    :
+              ((rg_operation == GREV)   && (!rg_32_bit)) ? grev.read   :
+              ((rg_operation == SHFL)   && (!rg_32_bit)) ? shfl.read   :
+              ((rg_operation == UNSHFL) && (!rg_32_bit)) ? unshfl.read :
+              ((rg_operation == BEXT)   && (!rg_32_bit)) ? bext.read   :
+              ((rg_operation == BDEP)   && (!rg_32_bit)) ? bdep.read   :
+              ((rg_operation == CLZ)    &&  (rg_32_bit)) ? clz32.read    :
+              ((rg_operation == CTZ)    &&  (rg_32_bit)) ? ctz32.read    :
+              ((rg_operation == PCNT)   &&  (rg_32_bit)) ? pcnt32.read   :
+              ((rg_operation == SRO)    &&  (rg_32_bit)) ? sro32.read    :
+              ((rg_operation == SLO)    &&  (rg_32_bit)) ? slo32.read    :
+              ((rg_operation == ROR)    &&  (rg_32_bit)) ? ror32.read    :
+              ((rg_operation == ROL)    &&  (rg_32_bit)) ? rol32.read    :
+//              ((rg_operation == GREV)   &&  (rg_32_bit)) ? grev.read   :
+//              ((rg_operation == SHFL)   &&  (rg_32_bit)) ? shfl.read   :
+//              ((rg_operation == UNSHFL) &&  (rg_32_bit)) ? unshfl.read :
+              ((rg_operation == BEXT)   &&  (rg_32_bit)) ? bext32.read   :
+              ((rg_operation == BDEP)   &&  (rg_32_bit)) ? bdep32.read   :
+              0;
+    `endif
 
     rg_rd <= res;
 
@@ -237,11 +278,17 @@ module mkModuleTb (Empty);
     end
   endrule: tb_dut_wait
 
-  `ifdef RV32
+//  `ifdef RV32
   Bool rs2_useful = !((rg_operation == CLZ)  || (rg_operation == CTZ)  || (rg_operation == PCNT));
-  `elsif RV64
-  Bool rs2_useful = !((rg_operation == CLZ)  || (rg_operation == CTZ)  || (rg_operation == PCNT) ||
-                      (rg_operation == CLZW) || (rg_operation == CTZW) || (rg_operation == PCNTW));
+//  `elsif RV64
+//  Bool rs2_useful = !((rg_operation == CLZ)  || (rg_operation == CTZ)  || (rg_operation == PCNT) ||
+//                      (rg_operation == CLZW) || (rg_operation == CTZW) || (rg_operation == PCNTW));
+//  `endif
+
+  `ifdef RV32
+  Bool inc_op = rg_operation != BDEP;
+  `else
+  Bool inc_op = (rg_operation != BDEP) || (!rg_32_bit);
   `endif
 
   rule tb_dut_return (rg_state == Dut_Return);
@@ -267,7 +314,7 @@ module mkModuleTb (Empty);
     else
     `endif
     if (rg_bram_offset != fromInteger(bram_limit)) rg_state <= Mem_Init;
-    else if (rg_operation != final_operation)      rg_state <= Op_Init;
+    else if (inc_op)                               rg_state <= Op_Init;
     else                                           rg_state <= Tb_Exit;
   endrule: tb_dut_return
 

--- a/bsv/TbMeta.bsv
+++ b/bsv/TbMeta.bsv
@@ -41,6 +41,17 @@ String unshfl_file  = bram_locate("unshfl");
 String bext_file    = bram_locate("bext"); 
 String bdep_file    = bram_locate("bdep"); 
 
+`ifdef RV64
+String clzw_file    = bram_locate("clzw"); 
+String ctzw_file    = bram_locate("ctzw"); 
+String pcntw_file   = bram_locate("pcntw"); 
+String srow_file    = bram_locate("srow"); 
+String slow_file    = bram_locate("slow"); 
+String rorw_file    = bram_locate("rorw"); 
+String rolw_file    = bram_locate("rolw"); 
+String bextw_file   = bram_locate("bextw"); 
+String bdepw_file   = bram_locate("bdepw");
+`endif
 
 typedef `TEST_COUNT BRAM_ENTRIES;
 typedef TLog #(BRAM_ENTRIES) LOG_BRAM_ENTRIES;

--- a/bsv/TbMeta.bsv
+++ b/bsv/TbMeta.bsv
@@ -42,15 +42,18 @@ String bext_file    = bram_locate("bext");
 String bdep_file    = bram_locate("bdep"); 
 
 `ifdef RV64
-String clzw_file    = bram_locate("clzw"); 
-String ctzw_file    = bram_locate("ctzw"); 
-String pcntw_file   = bram_locate("pcntw"); 
-String srow_file    = bram_locate("srow"); 
-String slow_file    = bram_locate("slow"); 
-String rorw_file    = bram_locate("rorw"); 
-String rolw_file    = bram_locate("rolw"); 
-String bextw_file   = bram_locate("bextw"); 
-String bdepw_file   = bram_locate("bdepw");
+String clz32_file    = bram_locate("clz32"); 
+String ctz32_file    = bram_locate("ctz32"); 
+String pcnt32_file   = bram_locate("pcnt32"); 
+String sro32_file    = bram_locate("sro32"); 
+String slo32_file    = bram_locate("slo32"); 
+String ror32_file    = bram_locate("ror32"); 
+String rol32_file    = bram_locate("rol32"); 
+String grev32_file   = bram_locate("grev32"); 
+String shfl32_file   = bram_locate("shfl32"); 
+String unshfl32_file = bram_locate("unshfl32"); 
+String bext32_file   = bram_locate("bext32"); 
+String bdep32_file   = bram_locate("bdep32");
 `endif
 
 typedef `TEST_COUNT BRAM_ENTRIES;

--- a/util/bitmanip.c
+++ b/util/bitmanip.c
@@ -249,4 +249,17 @@ xlen_t unshflw(xlen_t rs1, xlen_t rs2){
   return unshfl(x, shamt);
 }*/
 
+// 32 bit mode grev and shfl in RV64
+// not real insns, mainly for testing ease
+xlen_t grev_32(xlen_t rs1, xlen_t rs2){
+  return grev(rs1 & lower_32, rs2 & 31);
+}
+
+xlen_t shfl_32(xlen_t rs1, xlen_t rs2){
+  return shfl(rs1 & lower_32, rs2 & 15);
+}
+
+xlen_t unshfl_32(xlen_t rs1, xlen_t rs2){
+  return unshfl(rs1 & lower_32, rs2 & 15);
+}
 #endif

--- a/util/bitmanip.h
+++ b/util/bitmanip.h
@@ -52,6 +52,12 @@ xlen_t bdepw(xlen_t rs1, xlen_t rs2);
 // see comments in bitmanip.c for (un)shflw
 //xlen_t shflw  (xlen_t rs1, xlen_t rs2);
 //xlen_t unshflw(xlen_t rs1, xlen_t rs2);
+
+// see notes in bitmanip.c
+// used in bramGen, not invoked in repl64
+xlen_t grev_32  (xlen_t rs1, xlen_t rs2);
+xlen_t shfl_32  (xlen_t rs1, xlen_t rs2);
+xlen_t unshfl_32(xlen_t rs1, xlen_t rs2);
 #endif
 
 #endif //BITMANIP_H

--- a/util/bramGen.c
+++ b/util/bramGen.c
@@ -162,50 +162,62 @@ int main(int argc, char *argv[]){
   #ifdef RV64
   for(int i = 0; i < no_entries; i++)
     res[i] = clzw(rs1[i]);
-  xlen_hex_write("./clzw.hex", res, no_entries);
+  xlen_hex_write("./clz32.hex", res, no_entries);
 
   for(int i = 0; i < no_entries; i++)
     res[i] = ctzw(rs1[i]);
-  xlen_hex_write("./ctzw.hex", res, no_entries);
+  xlen_hex_write("./ctz32.hex", res, no_entries);
 
   for(int i = 0; i < no_entries; i++)
     res[i] = pcntw(rs1[i]);
-  xlen_hex_write("./pcntw.hex", res, no_entries);
+  xlen_hex_write("./pcnt32.hex", res, no_entries);
 
   for(int i = 0; i < no_entries; i++)
     res[i] = slow(rs1[i], rs2[i]);
-  xlen_hex_write("./slow.hex", res, no_entries);
+  xlen_hex_write("./slo32.hex", res, no_entries);
 
   for(int i = 0; i < no_entries; i++)
     res[i] = srow(rs1[i], rs2[i]);
-  xlen_hex_write("./srow.hex", res, no_entries);
+  xlen_hex_write("./sro32.hex", res, no_entries);
 
   for(int i = 0; i < no_entries; i++)
     res[i] = rolw(rs1[i], rs2[i]);
-  xlen_hex_write("./rolw.hex", res, no_entries);
+  xlen_hex_write("./rol32.hex", res, no_entries);
 
   for(int i = 0; i < no_entries; i++)
     res[i] = rorw(rs1[i], rs2[i]);
-  xlen_hex_write("./rorw.hex", res, no_entries);
+  xlen_hex_write("./ror32.hex", res, no_entries);
 
   for(int i = 0; i < no_entries; i++)
     res[i] = bextw(rs1[i], rs2[i]);
-  xlen_hex_write("./bextw.hex", res, no_entries);
+  xlen_hex_write("./bext32.hex", res, no_entries);
 
   for(int i = 0; i < no_entries; i++)
     res[i] = bdepw(rs1[i], rs2[i]);
-  xlen_hex_write("./bdepw.hex", res, no_entries);
+  xlen_hex_write("./bdep32.hex", res, no_entries);
 
 // see bitmanip.c for (un)shflw notes
 
 /*  for(int i = 0; i < no_entries; i++)
     res[i] = shflw(rs1[i], rs2[i]);
-  xlen_hex_write("./shflw.hex", res, no_entries);
+  xlen_hex_write("./shfl32.hex", res, no_entries);
 
   for(int i = 0; i < no_entries; i++)
     res[i] = unshflw(rs1[i], rs2[i]);
-  xlen_hex_write("./unshflw.hex", res, no_entries);*/
+  xlen_hex_write("./unshfl32.hex", res, no_entries);*/
 
+  // mainly for ease in testing
+  for(int i = 0; i < no_entries; i++)
+    res[i] = grev_32(rs1[i], rs2[i]);
+  xlen_hex_write("./grev32.hex", res, no_entries);
+
+  for(int i = 0; i < no_entries; i++)
+    res[i] = shfl_32(rs1[i], rs2[i]);
+  xlen_hex_write("./shfl32.hex", res, no_entries);
+
+  for(int i = 0; i < no_entries; i++)
+    res[i] = unshfl_32(rs1[i], rs2[i]);
+  xlen_hex_write("./unshfl32.hex", res, no_entries);
   #endif
 
   return 0;


### PR DESCRIPTION
# RV64 Iterative Model

Resolves #10 

BlueSpec iterative module and suporting code enhanced to address the need for RV64.  BitManipIter Module and all other code is good for supporting RV32 builds and RV64 builds that can operate in 32bit modes (insns like PCNTW, or if a proc has the ability to swap to an RV32 mode)

## Summary of Changes

### Makefile

- Add option to exit bluesim on first failure
- clean up all rule for ease of use in master

### README

- Update for work here

### BitManipIter

- function moved to Meta
- reg appears in RV64 for 32 bit mode operation
- rules and conditions updated to be flexible in 32 bit mode operation under RV64
- put method altered to be verbose in HW_DIAG builds, generalization with let bindings
- value get modified so that 32 bit mode in RV64 will mask out upper hw

### BitManipMeta

- gain a function from Iter Module
- function modifications for 32 bit under RV64

### bsv Makefile

- HARD FAIL build option 

### ModuleTb

- enhance for RV64 and 32 under that, HARD FAIL exits

### TbMeta

- 32 bit expectation hex files

### util sources

- 3 new 32 bit file targets, many renames (a la clzw.hex --> clz32.hex)